### PR TITLE
Visualizer and Updated Solver

### DIFF
--- a/exploration/YpPtVisualization.py
+++ b/exploration/YpPtVisualization.py
@@ -1,0 +1,140 @@
+import os
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.widgets import Slider, Button, CheckButtons
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from tracing.coleman_equations import equation_13, equation_14, equation_15
+
+
+def equation_13_14_15(x, y, y_dot_p_normalized, y_dot_t_normalized, sign):
+    x, y_squared, yt = x, np.square(y), y_dot_t_normalized * y
+    yp = y_dot_p_normalized * y
+    result_13 = equation_13(yp, x, y_squared, yt, sign)
+    result_14 = equation_14(yp, np.square(yp), y_squared, x, yt, sign)
+    result_15 = equation_15(yp, x, y_squared, sign)
+    return result_13, result_14, result_15
+
+
+y_dot_p_normalized_external = np.linspace(-1, 1, 1000)
+
+# Define initial parameters
+init_y = 0.9
+init_yt_normalized = 0.8
+init_x = 0.2
+main_sign = 1
+
+# Create the figure and the line that we will manipulate
+fig, ax = plt.subplots()
+yp_minimizer, pt, mu2 = equation_13_14_15(init_x, init_y, y_dot_p_normalized_external, init_yt_normalized, main_sign)
+line_yp, = plt.plot(
+    y_dot_p_normalized_external,
+    yp_minimizer,
+    color="red",
+    lw=2, label="Minimizer"
+)
+line_pt, = plt.plot(
+    y_dot_p_normalized_external,
+    pt,
+    color="green",
+    lw=2, label="pt"
+)
+line_mu2, = plt.plot(
+    y_dot_p_normalized_external,
+    mu2,
+    color="gold",
+    lw=2, label="mu^2"
+)
+
+plt.hlines([0, 1, -1], -1, 1, color='blue', label='y = 1,0,-1')
+
+ax.set_xlabel('y_dot_p_normalized')
+ax.set_ylim([-1.5, 1.5])
+ax.set_xlim([-1, 1])
+ax.legend()
+ax.autoscale(False)
+
+slider_color = 'lightgoldenrodyellow'
+ax.margins(x=0)
+
+# adjust the main plot to make room for the sliders
+plt.subplots_adjust(left=0.25, bottom=0.35)
+plt.title("YP and PT Visualizer")
+
+ax_yt = plt.axes([0.25, 0.1, 0.65, 0.03], facecolor=slider_color)
+yt_slider = Slider(
+    ax=ax_yt,
+    label='yt_norm',
+    valmin=-1,
+    valmax=1,
+    valinit=init_yt_normalized,
+)
+
+ax_y = plt.axes([0.25, 0.15, 0.65, 0.03], facecolor=slider_color)
+y_slider = Slider(
+    ax=ax_y,
+    label="y",
+    valmin=0,
+    valmax=10,
+    valinit=init_y,
+)
+
+ax_x = plt.axes([0.25, 0.2, 0.65, 0.03], facecolor=slider_color)
+x_slider = Slider(
+    ax=ax_x,
+    label="x",
+    valmin=0,
+    valmax=1,
+    valinit=init_x,
+)
+
+
+# The function to be called anytime a slider's value changes
+def update(_val):
+    yp_minimizer_internal, pt_internal, mu2_internal = equation_13_14_15(
+        x_slider.val,
+        y_slider.val,
+        y_dot_p_normalized_external,
+        yt_slider.val,
+        main_sign
+    )
+    line_yp.set_ydata(
+        yp_minimizer_internal
+    )
+    line_pt.set_ydata(
+        pt_internal
+    )
+    line_mu2.set_ydata(
+        mu2_internal
+    )
+    fig.canvas.draw_idle()
+
+
+def reset(_event):
+    yt_slider.reset()
+    y_slider.reset()
+    x_slider.reset()
+
+
+def toggle_ray_type(_label):
+    global main_sign
+    main_sign = -1 * main_sign
+    update(None)
+
+
+# register the update function with each slider
+yt_slider.on_changed(update)
+y_slider.on_changed(update)
+x_slider.on_changed(update)
+
+# Create a `matplotlib.widgets.Button` to reset the sliders to initial values.
+reset_ax = plt.axes([0.8, 0.025, 0.1, 0.04])
+reset_button = Button(reset_ax, 'Reset', color=slider_color, hovercolor='0.975')
+toggle_ax = plt.axes([0.55, 0.025, 0.2, 0.04])
+ray_button = CheckButtons(toggle_ax, ['Extraordinary'], [False])
+
+reset_button.on_clicked(reset)
+ray_button.on_clicked(toggle_ray_type)
+plt.show()

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ import matplotlib as mpl
 mpl.rcParams['figure.dpi'] = 500
 
 if __name__ == "__main__":
-    field = magnetic_fields.ZeroField()
+    field = magnetic_fields.DipoleField()
     path_start_point = Vector.spherical_to_cartesian(
         Vector.latitude_to_spherical(
             np.array([EARTH_RADIUS, 90 + 23.5, 133.7])))
@@ -36,7 +36,9 @@ if __name__ == "__main__":
     path_start = GreatCircleDeviation.from_path(np.linspace(0, 1, 52), np.linspace(0, 1, 2), other_path=path_generator)
     basic_tracer = Tracer(operating_frequency, atmosphere, field, path_start)
 
-    basic_tracer.trace()
+    basic_tracer.trace(use_cheater_solver=False)
+    basic_tracer.visualize(show_history=True)
+    basic_tracer.trace(use_cheater_solver=True, is_extraordinary_ray=True)
     basic_tracer.visualize(show_history=True)
 
     path_generator.using_high_ray = False
@@ -44,7 +46,10 @@ if __name__ == "__main__":
     basic_tracer.replace_path(GreatCircleDeviation.from_path(
         np.linspace(0, 1, 52), np.linspace(0, 1, 2), path_generator
     ))
-    basic_tracer.trace()
-    basic_tracer.visualize()
+
+    basic_tracer.trace(use_cheater_solver=False)
+    basic_tracer.visualize(show_history=True)
+    basic_tracer.trace(use_cheater_solver=True, is_extraordinary_ray=True)
+    basic_tracer.visualize(show_history=True)
 
     basic_tracer.cleanup()  # Should call after we are done with tracer to free up processes

--- a/tracing/tracer.py
+++ b/tracing/tracer.py
@@ -1,4 +1,6 @@
 import multiprocessing as mp
+import random
+import time
 import warnings
 from os.path import join as join_path
 from typing import Optional
@@ -245,7 +247,8 @@ class Tracer:
         # noinspection PyProtectedMember
         print(
             f"Calculating {total_diagonal_ints + off_diagonal_elements * 4} integrations "
-            f"with {self.pool._processes} processes ")
+            f"with {self.pool._processes} processes "
+        )
         for result in diagonal_d_results.get():
             index = int(result[0])
             gradient[index] = result[1]
@@ -328,9 +331,9 @@ def integrate_parameter(
     x = np.square(system_state.atmosphere.plasma_frequency(r) / system_state.operating_frequency)
     yt = Vector.row_dot_product(y_vec, t)
 
-    sign = -1
+    sign = 1
     if system_state.is_extraordinary_ray:
-        sign = 1
+        sign = -1
 
     # TODO: Fix real yp/pt solver
     if use_cheater_solver:
@@ -339,10 +342,14 @@ def integrate_parameter(
         solved_yp, solved_pt = calculate_yp_pt_real(
             x, y, y_squared, yt, sign=sign
         )
+    # plt.plot(solved_yp)
+    # plt.plot(solved_pt)
+    # plt.show()
+    # plt.close()
 
-    current_mu2 = equation_15(solved_yp, x, y_squared, sign=sign)
+    current_mu_squared = equation_15(solved_yp, x, y_squared, sign=sign)
 
-    dp_array = np.sqrt(current_mu2) * solved_pt * r_dot_norm
+    dp_array = np.sqrt(current_mu_squared) * solved_pt * r_dot_norm
     integration = simps(dp_array, dx=h)
     if show:
         fig, ax = plt.subplots(1, 1, figsize=(6, 4.5))


### PR DESCRIPTION
Adding updated solver for yp, pt. Still having issues with extraordinary rays (or when x > 1). 
This solver is also a factor or 20 slower than the cheating solver. This is because we have to iterate through using python. If we could find a more quickly convergent algorithm (maybe newton's method instead of brent's), or an algorithm implemented in C, we could reduce our time greatly here.

I also added a visualizer for the parameters. You can run this by `python exploration/YpPtVisualization.py`, and it will open up an interactive graph that shows mu, pt, and the minimizer function (the roots of this function occur at valid yp's)